### PR TITLE
Priority type generalization

### DIFF
--- a/Priority Queue Example/FastPriorityQueueExample.cs
+++ b/Priority Queue Example/FastPriorityQueueExample.cs
@@ -10,7 +10,7 @@ namespace Priority_Queue_Example
     public static class FastPriorityQueueExample
     {
         //The class to be enqueued.
-        public class User : FastPriorityQueueNode
+        public class User : FastPriorityQueueNode<int>
         {
             public string Name { get; private set; }
             public User(string name)
@@ -24,7 +24,7 @@ namespace Priority_Queue_Example
         public static void RunExample()
         {
             //First, we create the priority queue.  We'll specify a max of 10 users in the queue
-            FastPriorityQueue<User> priorityQueue = new FastPriorityQueue<User>(MAX_USERS_IN_QUEUE);
+            FastPriorityQueue<User,int> priorityQueue = new FastPriorityQueue<User,int>(MAX_USERS_IN_QUEUE);
 
             //Next, we'll create 5 users to enqueue
             User user1 = new User("1 - Jason");

--- a/Priority Queue Example/SimplePriorityQueueExample.cs
+++ b/Priority Queue Example/SimplePriorityQueueExample.cs
@@ -12,7 +12,7 @@ namespace Priority_Queue_Example
         public static void RunExample()
         {
             //First, we create the priority queue.
-            SimplePriorityQueue<string> priorityQueue = new SimplePriorityQueue<string>();
+            SimplePriorityQueue<string, int> priorityQueue = new SimplePriorityQueue<string, int>();
 
             //Now, let's add them all to the queue (in some arbitrary order)!
             priorityQueue.Enqueue("4 - Joseph", 4);

--- a/Priority Queue Tests/FastPriorityQueueTests.cs
+++ b/Priority Queue Tests/FastPriorityQueueTests.cs
@@ -6,11 +6,11 @@ using Priority_Queue;
 namespace Priority_Queue_Tests
 {
     [TestFixture]
-    internal class FastPriorityQueueTests : SharedFastPriorityQueueTests<FastPriorityQueue<Node>>
+    internal class FastPriorityQueueTests : SharedFastPriorityQueueTests<FastPriorityQueue<Node<int>,int>>
     {
-        protected override FastPriorityQueue<Node> CreateQueue()
+        protected override FastPriorityQueue<Node<int>,int> CreateQueue()
         {
-            return new FastPriorityQueue<Node>(100);
+            return new FastPriorityQueue<Node<int>,int>(100);
         }
 
         protected override bool IsValidQueue()

--- a/Priority Queue Tests/SharedFastPriorityQueueTests.cs
+++ b/Priority Queue Tests/SharedFastPriorityQueueTests.cs
@@ -7,7 +7,7 @@ namespace Priority_Queue_Tests
 {
     [TestFixture]
     internal abstract class SharedFastPriorityQueueTests<TQueue> : SharedPriorityQueueTests<TQueue>
-        where TQueue : IFixedSizePriorityQueue<Node>
+        where TQueue : IFixedSizePriorityQueue<Node<int>, int>
     {
         [Test]
         public void TestMaxNodes()
@@ -30,8 +30,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestResizeCopiesNodes()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            var node1 = new Node<int>(1);
+            var node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -47,10 +47,10 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestResizeQueueWasFull()
         {
-            List<Node> nodes = new List<Node>(Queue.MaxSize);
-            for(int i = 0; i < Queue.MaxSize; i++)
+            var nodes = new List<Node<int>>(Queue.MaxSize);
+            for (int i = 0; i < Queue.MaxSize; i++)
             {
-                Node node = new Node(i);
+                var node = new Node<int>(i);
                 Enqueue(node);
                 nodes.Insert(i, node);
             }
@@ -67,9 +67,9 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestResizeQueueBecomesFull()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
+            var node1 = new Node<int>(1);
+            var node2 = new Node<int>(2);
+            var node3 = new Node<int>(3);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -93,17 +93,17 @@ namespace Priority_Queue_Tests
         {
             for(int i = 0; i < Queue.MaxSize; i++)
             {
-                Node node = new Node(i);
+                Node<int> node = new Node<int>(i);
                 Enqueue(node);
             }
 
-            Assert.Throws<InvalidOperationException>(() => Queue.Enqueue(new Node(999), 999));
+            Assert.Throws<InvalidOperationException>(() => Queue.Enqueue(new Node<int>(999), 999));
         }
 
         [Test]
         public void TestDebugEnqueueThrowsOnAlreadyEnqueuedNode()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Enqueue(node);
 
@@ -119,8 +119,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugDequeueThrowsOnEmptyQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            var node1 = new Node<int>(1);
+            var node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -140,8 +140,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugFirstThrowsOnEmptyQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            var node1 = new Node<int>(1);
+            var node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -155,8 +155,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugDequeueThrowsOnCorruptedQueue()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            var node1 = new Node<int>(1);
+            var node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -169,7 +169,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugRemoveThrowsOnNodeNotInQueue()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Assert.Throws<InvalidOperationException>(() => Queue.Remove(node));
         }
@@ -177,8 +177,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugRemoveThrowsOnNodeNotInQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 
@@ -188,7 +188,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugRemoveThrowsOnNodeNotInQueue3()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Enqueue(node);
 
@@ -200,7 +200,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugUpdatePriorityThrowsOnNodeNotInQueue()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Assert.Throws<InvalidOperationException>(() => Queue.UpdatePriority(node, 2));
         }
@@ -208,8 +208,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugUpdatePriorityThrowsOnNodeNotInQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 
@@ -219,7 +219,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugUpdatePriorityThrowsOnNodeNotInQueue3()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Enqueue(node);
             Dequeue();
@@ -236,9 +236,9 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugResizeSizeTooSmall()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -259,8 +259,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugContainsOutOfBoundsCloseTo0()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 
@@ -272,8 +272,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugContainsOutOfBoundsVeryNegative()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 
@@ -285,8 +285,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugContainsOutOfBoundsAboveMaxSize()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 
@@ -298,8 +298,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDebugContainsOutOfBoundsVeryLarge()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
 

--- a/Priority Queue Tests/SharedPriorityQueueTests.cs
+++ b/Priority Queue Tests/SharedPriorityQueueTests.cs
@@ -4,9 +4,9 @@ using Priority_Queue;
 
 namespace Priority_Queue_Tests
 {
-    public class Node : StablePriorityQueueNode
+    public class Node<K> : StablePriorityQueueNode<K>
     {
-        public Node(int priority)
+        public Node(K priority)
         {
             Priority = priority;
         }
@@ -17,22 +17,22 @@ namespace Priority_Queue_Tests
         }
     }
 
-    public abstract class SharedPriorityQueueTests<TQueue> where TQueue : IPriorityQueue<Node>
+    public abstract class SharedPriorityQueueTests<TQueue> where TQueue : IPriorityQueue<Node<int>, int>
     {
         protected TQueue Queue { get; set; }
 
         protected abstract TQueue CreateQueue();
         protected abstract bool IsValidQueue();
 
-        protected void Enqueue(Node node)
+        protected void Enqueue(Node<int> node)
         {
             Queue.Enqueue(node, node.Priority);
             Assert.IsTrue(IsValidQueue());
         }
 
-        protected Node Dequeue()
+        protected Node<int> Dequeue()
         {
-            Node returnMe = Queue.Dequeue();
+            Node<int> returnMe = Queue.Dequeue();
             Assert.IsTrue(IsValidQueue());
             return returnMe;
         }
@@ -46,8 +46,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestSanity()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Assert.AreEqual(node1, node1);
             Assert.AreEqual(node2, node2);
@@ -59,7 +59,7 @@ namespace Priority_Queue_Tests
         {
             Assert.AreEqual(0, Queue.Count);
 
-            Enqueue(new Node(1));
+            Enqueue(new Node<int>(1));
             Assert.AreEqual(1, Queue.Count);
 
             Dequeue();
@@ -69,8 +69,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestFirst()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -83,14 +83,14 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestEnqueueWorksWithTwoNodesWithSamePriority()
         {
-            Node node11 = new Node(1);
-            Node node12 = new Node(1);
+            var node11 = new Node<int>(1);
+            var node12 = new Node<int>(1);
 
             Enqueue(node11);
             Enqueue(node12);
 
-            Node firstNode = Dequeue();
-            Node secondNode = Dequeue();
+            Node<int> firstNode = Dequeue();
+            Node<int> secondNode = Dequeue();
 
             //Assert we got the correct nodes, but since the queue might not be stable, the order doesn't matter
             Assert.IsTrue((firstNode == node11 && secondNode == node12) || (firstNode == node12 && secondNode == node11));
@@ -99,11 +99,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestSimpleQueue()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node2);
             Enqueue(node5);
@@ -121,11 +121,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestForwardOrder()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -143,11 +143,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestBackwardOrder()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node5);
             Enqueue(node4);
@@ -165,11 +165,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestAddingSameNodesLater()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node2);
             Enqueue(node5);
@@ -199,11 +199,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestAddingDifferentNodesLater()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node2);
             Enqueue(node5);
@@ -217,11 +217,11 @@ namespace Priority_Queue_Tests
             Assert.AreEqual(node4, Dequeue());
             Assert.AreEqual(node5, Dequeue());
 
-            Node node6 = new Node(6);
-            Node node7 = new Node(7);
-            Node node8 = new Node(8);
-            Node node9 = new Node(9);
-            Node node10 = new Node(10);
+            Node<int> node6 = new Node<int>(6);
+            Node<int> node7 = new Node<int>(7);
+            Node<int> node8 = new Node<int>(8);
+            Node<int> node9 = new Node<int>(9);
+            Node<int> node10 = new Node<int>(10);
 
             Enqueue(node6);
             Enqueue(node7);
@@ -239,11 +239,11 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestClear()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
-            Node node3 = new Node(3);
-            Node node4 = new Node(4);
-            Node node5 = new Node(5);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
+            Node<int> node4 = new Node<int>(4);
+            Node<int> node5 = new Node<int>(5);
 
             Enqueue(node2);
             Enqueue(node5);

--- a/Priority Queue Tests/SharedStablePriorityQueueTests.cs
+++ b/Priority Queue Tests/SharedStablePriorityQueueTests.cs
@@ -12,13 +12,13 @@ namespace Priority_Queue_Tests
     //require multiple inheritance..
     public static class SharedStablePriorityQueueTests
     {
-        public static void TestOrderedQueue(Action<Node> enqueue, Func<Node> dequeue)
+        public static void TestOrderedQueue(Action<Node<int>> enqueue, Func<Node<int>> dequeue)
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(1);
-            Node node3 = new Node(1);
-            Node node4 = new Node(1);
-            Node node5 = new Node(1);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(1);
+            Node<int> node3 = new Node<int>(1);
+            Node<int> node4 = new Node<int>(1);
+            Node<int> node5 = new Node<int>(1);
 
             enqueue(node1);
             enqueue(node2);
@@ -33,33 +33,33 @@ namespace Priority_Queue_Tests
             Assert.AreEqual(node5, dequeue());
         }
 
-        public static void TestMoreComplicatedOrderedQueue(Action<Node> enqueue, Func<Node> dequeue)
+        public static void TestMoreComplicatedOrderedQueue(Action<Node<int>> enqueue, Func<Node<int>> dequeue)
         {
-            Node node11 = new Node(1);
-            Node node12 = new Node(1);
-            Node node13 = new Node(1);
-            Node node14 = new Node(1);
-            Node node15 = new Node(1);
-            Node node21 = new Node(2);
-            Node node22 = new Node(2);
-            Node node23 = new Node(2);
-            Node node24 = new Node(2);
-            Node node25 = new Node(2);
-            Node node31 = new Node(3);
-            Node node32 = new Node(3);
-            Node node33 = new Node(3);
-            Node node34 = new Node(3);
-            Node node35 = new Node(3);
-            Node node41 = new Node(4);
-            Node node42 = new Node(4);
-            Node node43 = new Node(4);
-            Node node44 = new Node(4);
-            Node node45 = new Node(4);
-            Node node51 = new Node(5);
-            Node node52 = new Node(5);
-            Node node53 = new Node(5);
-            Node node54 = new Node(5);
-            Node node55 = new Node(5);
+            Node<int> node11 = new Node<int>(1);
+            Node<int> node12 = new Node<int>(1);
+            Node<int> node13 = new Node<int>(1);
+            Node<int> node14 = new Node<int>(1);
+            Node<int> node15 = new Node<int>(1);
+            Node<int> node21 = new Node<int>(2);
+            Node<int> node22 = new Node<int>(2);
+            Node<int> node23 = new Node<int>(2);
+            Node<int> node24 = new Node<int>(2);
+            Node<int> node25 = new Node<int>(2);
+            Node<int> node31 = new Node<int>(3);
+            Node<int> node32 = new Node<int>(3);
+            Node<int> node33 = new Node<int>(3);
+            Node<int> node34 = new Node<int>(3);
+            Node<int> node35 = new Node<int>(3);
+            Node<int> node41 = new Node<int>(4);
+            Node<int> node42 = new Node<int>(4);
+            Node<int> node43 = new Node<int>(4);
+            Node<int> node44 = new Node<int>(4);
+            Node<int> node45 = new Node<int>(4);
+            Node<int> node51 = new Node<int>(5);
+            Node<int> node52 = new Node<int>(5);
+            Node<int> node53 = new Node<int>(5);
+            Node<int> node54 = new Node<int>(5);
+            Node<int> node55 = new Node<int>(5);
 
             enqueue(node31);
             enqueue(node51);

--- a/Priority Queue Tests/SimplePriorityQueueTests.cs
+++ b/Priority Queue Tests/SimplePriorityQueueTests.cs
@@ -6,11 +6,11 @@ using Priority_Queue;
 namespace Priority_Queue_Tests
 {
     [TestFixture]
-    public class SimplePriorityQueueTests : SharedPriorityQueueTests<SimplePriorityQueue<Node>>
+    public class SimplePriorityQueueTests : SharedPriorityQueueTests<SimplePriorityQueue<Node<int>,int>>
     {
-        protected override SimplePriorityQueue<Node> CreateQueue()
+        protected override SimplePriorityQueue<Node<int>,int> CreateQueue()
         {
-            return new SimplePriorityQueue<Node>();
+            return new SimplePriorityQueue<Node<int>,int>();
         }
 
         protected override bool IsValidQueue()
@@ -35,13 +35,13 @@ namespace Priority_Queue_Tests
         {
             for(int i = 0; i < 1000; i++)
             {
-                Enqueue(new Node(i));
+                Enqueue(new Node<int>(i));
                 Assert.AreEqual(i + 1, Queue.Count);
             }
 
             for(int i = 0; i < 1000; i++)
             {
-                Node node = Dequeue();
+                var node = Dequeue();
                 Assert.AreEqual(i, node.Priority);
             }
         }
@@ -55,8 +55,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestDequeueThrowsOnEmptyQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -76,8 +76,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestFirstThrowsOnEmptyQueue2()
         {
-            Node node1 = new Node(1);
-            Node node2 = new Node(2);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node2 = new Node<int>(2);
 
             Enqueue(node1);
             Enqueue(node2);
@@ -91,7 +91,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestEnqueueRemovesOneCopyOfItem()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Enqueue(node);
             Enqueue(node);
@@ -113,8 +113,8 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestEnqueueRemovesFirstCopyOfItem()
         {
-            Node node11 = new Node(1);
-            Node node12 = new Node(1);
+            Node<int> node11 = new Node<int>(1);
+            Node<int> node12 = new Node<int>(1);
 
             Enqueue(node11);
             Enqueue(node12);
@@ -132,10 +132,10 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestMultipleCopiesOfSameItem()
         {
-            Node node1 = new Node(1);
-            Node node21 = new Node(2);
-            Node node22 = new Node(2);
-            Node node3 = new Node(3);
+            Node<int> node1 = new Node<int>(1);
+            Node<int> node21 = new Node<int>(2);
+            Node<int> node22 = new Node<int>(2);
+            Node<int> node3 = new Node<int>(3);
 
             Enqueue(node1);
             Enqueue(node21);
@@ -163,7 +163,7 @@ namespace Priority_Queue_Tests
             Assert.AreEqual(1, Queue.Count);
             Assert.AreEqual(null, Queue.First);
             Assert.IsTrue(Queue.Contains(null));
-            Assert.IsFalse(Queue.Contains(new Node(1)));
+            Assert.IsFalse(Queue.Contains(new Node<int>(1)));
 
             Assert.AreEqual(null, Dequeue());
 
@@ -174,7 +174,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestRemoveThrowsOnNodeNotInQueue()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Assert.Throws<InvalidOperationException>(() => Queue.Remove(node));
         }
@@ -182,7 +182,7 @@ namespace Priority_Queue_Tests
         [Test]
         public void TestUpdatePriorityThrowsOnNodeNotInQueue()
         {
-            Node node = new Node(1);
+            Node<int> node = new Node<int>(1);
 
             Assert.Throws<InvalidOperationException>(() => Queue.UpdatePriority(node, 2));
         }

--- a/Priority Queue Tests/StablePriorityQueueTests.cs
+++ b/Priority Queue Tests/StablePriorityQueueTests.cs
@@ -6,11 +6,11 @@ using Priority_Queue;
 namespace Priority_Queue_Tests
 {
     [TestFixture]
-    internal class StablePriorityQueueTests : SharedFastPriorityQueueTests<StablePriorityQueue<Node>>
+    internal class StablePriorityQueueTests : SharedFastPriorityQueueTests<StablePriorityQueue<Node<int>,int>>
     {
-        protected override StablePriorityQueue<Node> CreateQueue()
+        protected override StablePriorityQueue<Node<int>,int> CreateQueue()
         {
-            return new StablePriorityQueue<Node>(100);
+            return new StablePriorityQueue<Node<int>,int>(100);
         }
 
         protected override bool IsValidQueue()

--- a/Priority Queue/FastPriorityQueue.cs
+++ b/Priority Queue/FastPriorityQueue.cs
@@ -10,9 +10,10 @@ namespace Priority_Queue
     /// See https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp/wiki/Getting-Started for more information
     /// </summary>
     /// <typeparam name="T">The values in the queue.  Must extend the FastPriorityQueueNode class</typeparam>
-    public sealed class FastPriorityQueue<T> : IFixedSizePriorityQueue<T>
-        where T : FastPriorityQueueNode
-    {
+    public sealed class FastPriorityQueue<T, K> : IFixedSizePriorityQueue<T, K>
+        where T : FastPriorityQueueNode<K>
+		where K : IComparable
+	{
         private int _numNodes;
         private T[] _nodes;
 
@@ -101,7 +102,7 @@ namespace Priority_Queue
         #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
-        public void Enqueue(T node, float priority)
+        public void Enqueue(T node, K priority)
         {
             #if DEBUG
             if(node == null)
@@ -227,7 +228,7 @@ namespace Priority_Queue
         #endif
         private bool HasHigherPriority(T higher, T lower)
         {
-            return (higher.Priority < lower.Priority);
+            return higher.Priority.CompareTo(lower.Priority) < 0;
         }
 
         /// <summary>
@@ -312,7 +313,7 @@ namespace Priority_Queue
         #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
-        public void UpdatePriority(T node, float priority)
+        public void UpdatePriority(T node, K priority)
         {
             #if DEBUG
             if(node == null)

--- a/Priority Queue/FastPriorityQueueNode.cs
+++ b/Priority Queue/FastPriorityQueueNode.cs
@@ -1,12 +1,12 @@
 ﻿namespace Priority_Queue
 {
-    public class FastPriorityQueueNode
+    public class FastPriorityQueueNode<K>
     {
         /// <summary>
         /// The Priority to insert this node at.  Must be set BEFORE adding a node to the queue (ideally just once, in the node's constructor).
         /// Should not be manually edited once the node has been enqueued - use queue.UpdatePriority() instead
         /// </summary>
-        public float Priority { get; protected internal set; }
+        public K Priority { get; protected internal set; }
 
         /// <summary>
         /// Represents the current position in the queue

--- a/Priority Queue/IFixedSizePriorityQueue.cs
+++ b/Priority Queue/IFixedSizePriorityQueue.cs
@@ -7,7 +7,7 @@ namespace Priority_Queue
     /// <summary>
     /// A helper-interface only needed to make writing unit tests a bit easier (hence the 'internal' access modifier)
     /// </summary>
-    internal interface IFixedSizePriorityQueue<TItem> : IPriorityQueue<TItem>
+    internal interface IFixedSizePriorityQueue<TItem, KPriority> : IPriorityQueue<TItem, KPriority>
     {
         /// <summary>
         /// Resize the queue so it can accept more nodes.  All currently enqueued nodes are remain.

--- a/Priority Queue/IPriorityQueue.cs
+++ b/Priority Queue/IPriorityQueue.cs
@@ -7,13 +7,13 @@ namespace Priority_Queue
     /// For speed purposes, it is actually recommended that you *don't* access the priority queue through this interface, since the JIT can
     /// (theoretically?) optimize method calls from concrete-types slightly better.
     /// </summary>
-    public interface IPriorityQueue<T> : IEnumerable<T>
+    public interface IPriorityQueue<T, K> : IEnumerable<T>
     {
         /// <summary>
         /// Enqueue a node to the priority queue.  Lower values are placed in front. Ties are broken by first-in-first-out.
         /// See implementation for how duplicates are handled.
         /// </summary>
-        void Enqueue(T node, float priority);
+        void Enqueue(T node, K priority);
 
         /// <summary>
         /// Removes the head of the queue (node with minimum priority; ties are broken by order of insertion), and returns it.
@@ -38,7 +38,7 @@ namespace Priority_Queue
         /// <summary>
         /// Call this method to change the priority of a node.  
         /// </summary>
-        void UpdatePriority(T node, float priority);
+        void UpdatePriority(T node, K priority);
 
         /// <summary>
         /// Returns the head of the queue, without removing it (use Dequeue() for that).

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -9,9 +9,10 @@ namespace Priority_Queue
     /// FastPriorityQueue
     /// </summary>
     /// <typeparam name="T">The type to enqueue</typeparam>
-    public sealed class SimplePriorityQueue<T> : IPriorityQueue<T>
+    public sealed class SimplePriorityQueue<T, K> : IPriorityQueue<T, K>
+		where K : IComparable
     {
-        private class SimpleNode : StablePriorityQueueNode
+        private class SimpleNode : StablePriorityQueueNode<K>
         {
             public T Data { get; private set; }
 
@@ -22,11 +23,11 @@ namespace Priority_Queue
         }
 
         private const int INITIAL_QUEUE_SIZE = 10;
-        private readonly StablePriorityQueue<SimpleNode> _queue;
+        private readonly StablePriorityQueue<SimpleNode, K> _queue;
 
         public SimplePriorityQueue()
         {
-            _queue = new StablePriorityQueue<SimpleNode>(INITIAL_QUEUE_SIZE);
+            _queue = new StablePriorityQueue<SimpleNode, K>(INITIAL_QUEUE_SIZE);
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace Priority_Queue
         /// Duplicates are allowed.
         /// O(log n)
         /// </summary>
-        public void Enqueue(T item, float priority)
+        public void Enqueue(T item, K priority)
         {
             lock(_queue)
             {
@@ -182,7 +183,7 @@ namespace Priority_Queue
         /// to update all of them, please wrap your items in a wrapper class so they can be distinguished).
         /// O(n)
         /// </summary>
-        public void UpdatePriority(T item, float priority)
+        public void UpdatePriority(T item, K priority)
         {
             lock (_queue)
             {

--- a/Priority Queue/StablePriorityQueue.cs
+++ b/Priority Queue/StablePriorityQueue.cs
@@ -11,9 +11,10 @@ namespace Priority_Queue
     /// See https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp/wiki/Getting-Started for more information
     /// </summary>
     /// <typeparam name="T">The values in the queue.  Must extend the StablePriorityQueueNode class</typeparam>
-    public sealed class StablePriorityQueue<T> : IFixedSizePriorityQueue<T>
-        where T : StablePriorityQueueNode
-    {
+    public sealed class StablePriorityQueue<T, K> : IFixedSizePriorityQueue<T, K>
+        where T : StablePriorityQueueNode<K>
+		where K : IComparable
+	{
         private int _numNodes;
         private T[] _nodes;
         private long _numNodesEverEnqueued;
@@ -104,7 +105,7 @@ namespace Priority_Queue
         #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
-        public void Enqueue(T node, float priority)
+        public void Enqueue(T node, K priority)
         {
             #if DEBUG
             if(node == null)
@@ -231,8 +232,8 @@ namespace Priority_Queue
         #endif
         private bool HasHigherPriority(T higher, T lower)
         {
-            return (higher.Priority < lower.Priority ||
-                (higher.Priority == lower.Priority && higher.InsertionIndex < lower.InsertionIndex));
+			var cmp = higher.Priority.CompareTo(lower.Priority);
+            return (cmp < 0 || (cmp == 0 && higher.InsertionIndex < lower.InsertionIndex));
         }
 
         /// <summary>
@@ -317,7 +318,7 @@ namespace Priority_Queue
         #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
-        public void UpdatePriority(T node, float priority)
+        public void UpdatePriority(T node, K priority)
         {
             #if DEBUG
             if(node == null)

--- a/Priority Queue/StablePriorityQueueNode.cs
+++ b/Priority Queue/StablePriorityQueueNode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Priority_Queue
 {
-    public class StablePriorityQueueNode : FastPriorityQueueNode
+    public class StablePriorityQueueNode<K> : FastPriorityQueueNode<K>
     {
         /// <summary>
         /// Represents the order the node was inserted in

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Features ###
 * Faster (for path-finding, at least) than any other C# priority queue out there!
 * Easy to use
-* Configurable priority type (numbers, dates, whatever IComparable!)
+* Configurable priority type (numbers, dates, strings, whatever IComparable!)
 * No dependencies on third-party libraries
 * Free for both personal and commercial use
 * Implements `IEnumerable<T>` for LINQ support!

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ### Features ###
 * Faster (for path-finding, at least) than any other C# priority queue out there!
 * Easy to use
+* Configurable priority type (numbers, dates, whatever IComparable!)
 * No dependencies on third-party libraries
 * Free for both personal and commercial use
 * Implements `IEnumerable<T>` for LINQ support!


### PR DESCRIPTION
BlueRaja created a great priority queue library for .NET which style I really like. However, I was surprised that only the type of queue elements (T) is generalized as in "xxxPriorityQueue of T", while the priorities must be "float" numbers. That limits the library's usage. I changed the library so that the type of priority value is arbitrary, given that it is IComparable, as in "xxxPriorityQueue of T, K".
Please approve my pull request to the main repository.
