### PR TITLE
Fix for runtime failure when NuGet package is installed in UWP App

### DIFF
--- a/Priority Queue PCL/Priority Queue PCL.csproj
+++ b/Priority Queue PCL/Priority Queue PCL.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Priority_Queue</RootNamespace>
-    <AssemblyName>Priority Queue PCL</AssemblyName>
+    <AssemblyName>Priority Queue</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Priority Queue PCL.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\Priority Queue.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Priority Queue PCL/Properties/AssemblyInfo.cs
+++ b/Priority Queue PCL/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.3")]
-[assembly: AssemblyFileVersion("4.0.3")]
+[assembly: AssemblyVersion("4.0.4")]
+[assembly: AssemblyFileVersion("4.0.4")]

--- a/Priority Queue UWP/Priority Queue UWP.csproj
+++ b/Priority Queue UWP/Priority Queue UWP.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Priority_Queue</RootNamespace>
-    <AssemblyName>Priority Queue UWP</AssemblyName>
+    <AssemblyName>Priority Queue</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -33,7 +33,7 @@
     <DefineConstants>TRACE;NET_VERSION_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Priority Queue UWP.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\Priority Queue.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Priority Queue UWP/Properties/AssemblyInfo.cs
+++ b/Priority Queue UWP/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.3")]
-[assembly: AssemblyFileVersion("4.0.3")]
+[assembly: AssemblyVersion("4.0.4")]
+[assembly: AssemblyFileVersion("4.0.4")]

--- a/Priority Queue/Priority Queue.nuspec
+++ b/Priority Queue/Priority Queue.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>OptimizedPriorityQueue</id>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
     <title>Highly Optimized Priority Queue</title>
     <authors>BlueRaja</authors>
     <owners>BlueRaja</owners>
@@ -23,12 +23,12 @@
     <file src="bin\Release\net45\Priority Queue.pdb" target="lib\net45\Priority Queue.pdb" />
     <file src="bin\Release\net45\Priority Queue.xml" target="lib\net45\Priority Queue.xml" />
     
-    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue UWP.dll" target="lib\netstandard1.0\Priority Queue.dll" />
-    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue UWP.pdb" target="lib\netstandard1.0\Priority Queue.pdb" />
-    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue UWP.xml" target="lib\netstandard1.0\Priority Queue.xml" />
+    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue.dll" target="lib\netstandard1.0\Priority Queue.dll" />
+    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue.pdb" target="lib\netstandard1.0\Priority Queue.pdb" />
+    <file src="..\Priority Queue UWP\bin\Release\netcore45\Priority Queue.xml" target="lib\netstandard1.0\Priority Queue.xml" />
     
-    <file src="..\Priority Queue PCL\bin\Release\Priority Queue PCL.dll" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.dll" />
-    <file src="..\Priority Queue PCL\bin\Release\Priority Queue PCL.pdb" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.pdb" />
-    <file src="..\Priority Queue PCL\bin\Release\Priority Queue PCL.xml" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.xml" />
+    <file src="..\Priority Queue PCL\bin\Release\Priority Queue.dll" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.dll" />
+    <file src="..\Priority Queue PCL\bin\Release\Priority Queue.pdb" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.pdb" />
+    <file src="..\Priority Queue PCL\bin\Release\Priority Queue.xml" target="lib\portable-net40+sl5+win8+wpa81+wp8\Priority Queue.xml" />
   </files>
 </package>


### PR DESCRIPTION
This fixes issue #24 
Just renames assemblies so the src and target names in the nuspec file match.