### PR TITLE
Many various optimizations

### DIFF
--- a/Priority Queue Benchmarks/Benchmarks.cs
+++ b/Priority Queue Benchmarks/Benchmarks.cs
@@ -15,6 +15,8 @@ namespace Priority_Queue_Benchmarks
         public int QueueSize;
 
         public FastPriorityQueueNode[] Nodes;
+        public int[] RandomPriorities;
+        public int[] RandomUpdatePriorities;
 
         private FastPriorityQueue<FastPriorityQueueNode> Queue;
 
@@ -23,9 +25,14 @@ namespace Priority_Queue_Benchmarks
         {
             Queue = new FastPriorityQueue<FastPriorityQueueNode>(QueueSize);
             Nodes = new FastPriorityQueueNode[QueueSize];
+            RandomPriorities = new int[QueueSize];
+            RandomUpdatePriorities = new int[QueueSize];
+            Random rand = new Random(34829061);
             for(int i = 0; i < QueueSize; i++)
             {
                 Nodes[i] = new FastPriorityQueueNode();
+                RandomPriorities[i] = rand.Next(16777216); // constrain to range float can hold with no rounding
+                RandomUpdatePriorities[i] = rand.Next(16777216); // constrain to range float can hold with no rounding
             }
         }
 
@@ -56,9 +63,19 @@ namespace Priority_Queue_Benchmarks
         }
 
         [Benchmark]
+        public void EnqueueRandom()
+        {
+            Queue.Clear();
+            for(int i = 0; i < QueueSize; i++)
+            {
+                Queue.Enqueue(Nodes[i], RandomPriorities[i]);
+            }
+        }
+
+        [Benchmark]
         public void EnqueueDequeue()
         {
-            Enqueue();
+            EnqueueRandom();
 
             for(int i = 0; i < QueueSize; i++)
             {
@@ -69,23 +86,25 @@ namespace Priority_Queue_Benchmarks
         [Benchmark]
         public void EnqueueUpdatePriority()
         {
-            Enqueue();
+            EnqueueRandom();
 
             for(int i = 0; i < QueueSize; i++)
             {
-                Queue.UpdatePriority(Queue.First, QueueSize-i);
+                Queue.UpdatePriority(Nodes[i], RandomUpdatePriorities[i]);
             }
         }
 
         [Benchmark]
-        public void EnqueueContains()
+        public bool EnqueueContains()
         {
-            Enqueue();
+            EnqueueRandom();
+            bool ret = true; // to ensure the compiler doesn't optimize the contains calls out of existence
 
             for(int i = 0; i < QueueSize; i++)
             {
-                Queue.Contains(Nodes[i]);
+                ret &= Queue.Contains(Nodes[i]);
             }
+            return ret;
         }
     }
 }

--- a/Priority Queue Benchmarks/Benchmarks.cs
+++ b/Priority Queue Benchmarks/Benchmarks.cs
@@ -150,5 +150,19 @@ namespace Priority_Queue_Benchmarks
             }
             return ret;
         }
+
+        [Benchmark]
+        public float EnqueueEnumerator()
+        {
+            Enqueue();
+            float prioritySum = 0;
+
+            foreach(FastPriorityQueueNode node in Queue)
+            {
+                prioritySum += node.Priority;
+            }
+
+            return prioritySum;
+        }
     }
 }

--- a/Priority Queue Benchmarks/Benchmarks.cs
+++ b/Priority Queue Benchmarks/Benchmarks.cs
@@ -75,6 +75,28 @@ namespace Priority_Queue_Benchmarks
         [Benchmark]
         public void EnqueueDequeue()
         {
+            Enqueue();
+
+            for(int i = 0; i < QueueSize; i++)
+            {
+                Queue.Dequeue();
+            }
+        }
+
+        [Benchmark]
+        public void EnqueueBackwardsDequeue()
+        {
+            EnqueueBackwards();
+
+            for(int i = 0; i < QueueSize; i++)
+            {
+                Queue.Dequeue();
+            }
+        }
+
+        [Benchmark]
+        public void EnqueueRandomDequeue()
+        {
             EnqueueRandom();
 
             for(int i = 0; i < QueueSize; i++)
@@ -85,6 +107,28 @@ namespace Priority_Queue_Benchmarks
 
         [Benchmark]
         public void EnqueueUpdatePriority()
+        {
+            Enqueue();
+
+            for(int i = 0; i < QueueSize; i++)
+            {
+                Queue.UpdatePriority(Nodes[i], QueueSize - i);
+            }
+        }
+
+        [Benchmark]
+        public void EnqueueBackwardsUpdatePriority()
+        {
+            EnqueueBackwards();
+
+            for(int i = 0; i < QueueSize; i++)
+            {
+                Queue.UpdatePriority(Nodes[i], QueueSize - i);
+            }
+        }
+
+        [Benchmark]
+        public void EnqueueRandomUpdatePriority()
         {
             EnqueueRandom();
 
@@ -97,7 +141,7 @@ namespace Priority_Queue_Benchmarks
         [Benchmark]
         public bool EnqueueContains()
         {
-            EnqueueRandom();
+            Enqueue();
             bool ret = true; // to ensure the compiler doesn't optimize the contains calls out of existence
 
             for(int i = 0; i < QueueSize; i++)

--- a/Priority Queue/FastPriorityQueue.cs
+++ b/Priority Queue/FastPriorityQueue.cs
@@ -262,7 +262,9 @@ namespace Priority_Queue
         /// If queue is empty, result is undefined
         /// O(log n)
         /// </summary>
+        #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
         public T Dequeue()
         {
             #if DEBUG
@@ -283,7 +285,7 @@ namespace Priority_Queue
             if (1 == _numNodes)
             {
                 _nodes[_numNodes] = null;
-                _numNodes--;
+                _numNodes = 0;
                 return returnMe;
             }
 

--- a/Priority Queue/FastPriorityQueue.cs
+++ b/Priority Queue/FastPriorityQueue.cs
@@ -122,7 +122,7 @@ namespace Priority_Queue
             _numNodes++;
             _nodes[_numNodes] = node;
             node.QueueIndex = _numNodes;
-            CascadeUp(_nodes[_numNodes]);
+            CascadeUp(node);
         }
 
         #if NET_VERSION_4_5
@@ -130,32 +130,41 @@ namespace Priority_Queue
         #endif
         private void Swap(T node1, T node2)
         {
+            // Cache to local for faster repeated access
+            int index1 = node1.QueueIndex;
+            int index2 = node2.QueueIndex;
+
             //Swap the nodes
-            _nodes[node1.QueueIndex] = node2;
-            _nodes[node2.QueueIndex] = node1;
+            _nodes[index1] = node2;
+            _nodes[index2] = node1;
 
             //Swap their indicies
-            int temp = node1.QueueIndex;
-            node1.QueueIndex = node2.QueueIndex;
-            node2.QueueIndex = temp;
+            node1.QueueIndex = index2;
+            node2.QueueIndex = index1;
         }
 
         //Performance appears to be slightly better when this is NOT inlined o_O
         private void CascadeUp(T node)
         {
             //aka Heapify-up
-            int parent = node.QueueIndex / 2;
-            while(parent >= 1)
+            int nodeIndex = node.QueueIndex;
+            int parentIndex = nodeIndex >> 1;
+            float nodePriority = node.Priority;
+            while(parentIndex >= 1)
             {
-                T parentNode = _nodes[parent];
-                if(HasHigherPriority(parentNode, node))
+                T parent = _nodes[parentIndex];
+                if(parent.Priority < nodePriority)
                     break;
 
-                //Node has lower priority value, so move it up the heap
-                Swap(node, parentNode); //For some reason, this is faster with Swap() rather than (less..?) individual operations, like in CascadeDown()
+                //Node has lower priority value, so move parent down the heap to make room
+                _nodes[nodeIndex] = parent;
+                parent.QueueIndex = nodeIndex;
 
-                parent = node.QueueIndex / 2;
+                nodeIndex = parentIndex;
+                parentIndex >>= 1;
             }
+            _nodes[nodeIndex] = node;
+            node.QueueIndex = nodeIndex;
         }
 
         #if NET_VERSION_4_5
@@ -164,56 +173,74 @@ namespace Priority_Queue
         private void CascadeDown(T node)
         {
             //aka Heapify-down
-            T newParent;
             int finalQueueIndex = node.QueueIndex;
             while(true)
             {
-                newParent = node;
                 int childLeftIndex = 2 * finalQueueIndex;
 
-                //Check if the left-child is higher-priority than the current node
+                // If leaf node, we're done
                 if(childLeftIndex > _numNodes)
                 {
-                    //This could be placed outside the loop, but then we'd have to check newParent != node twice
                     node.QueueIndex = finalQueueIndex;
                     _nodes[finalQueueIndex] = node;
                     break;
                 }
 
-                T childLeft = _nodes[childLeftIndex];
-                if(HasHigherPriority(childLeft, newParent))
-                {
-                    newParent = childLeft;
-                }
-
-                //Check if the right-child is higher-priority than either the current node or the left child
+                // Check if the left-child is higher-priority than the current node
                 int childRightIndex = childLeftIndex + 1;
-                if(childRightIndex <= _numNodes)
+                T childLeft = _nodes[childLeftIndex];
+                if(HasHigherPriority(childLeft, node))
                 {
-                    T childRight = _nodes[childRightIndex];
-                    if(HasHigherPriority(childRight, newParent))
+                    // Check if there is a right child. If not, swap and finish.
+                    if(childRightIndex > _numNodes)
                     {
-                        newParent = childRight;
+                        node.QueueIndex = childLeftIndex;
+                        childLeft.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childLeft;
+                        _nodes[childLeftIndex] = node;
+                        break;
+                    }
+                    // Check if the left-child is higher-priority than the right-child
+                    T childRight = _nodes[childRightIndex];
+                    if (HasHigherPriority(childLeft, childRight))
+                    {
+                        // left is highest, move it up and continue
+                        childLeft.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childLeft;
+                        finalQueueIndex = childLeftIndex;
+                    }
+                    else
+                    {
+                        // right is even higher, move it up and continue
+                        childRight.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childRight;
+                        finalQueueIndex = childRightIndex;
                     }
                 }
-
-                //If either of the children has higher (smaller) priority, swap and continue cascading
-                if(newParent != node)
+                // Not swapping with left-child, does right-child exist?
+                else if (childRightIndex > _numNodes)
                 {
-                    //Move new parent to its new index.  node will be moved once, at the end
-                    //Doing it this way is one less assignment operation than calling Swap()
-                    _nodes[finalQueueIndex] = newParent;
-
-                    int temp = newParent.QueueIndex;
-                    newParent.QueueIndex = finalQueueIndex;
-                    finalQueueIndex = temp;
+                    node.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = node;
+                    break;
                 }
                 else
                 {
-                    //See note above
-                    node.QueueIndex = finalQueueIndex;
-                    _nodes[finalQueueIndex] = node;
-                    break;
+                    // Check if the right-child is higher-priority than the current node
+                    T childRight = _nodes[childRightIndex];
+                    if (HasHigherPriority(childRight, node))
+                    {
+                        childRight.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childRight;
+                        finalQueueIndex = childRightIndex;
+                    }
+                    // Neither child is higher-priority than current, so finish and stop.
+                    else
+                    {
+                        node.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = node;
+                        break;
+                    }
                 }
             }
         }
@@ -235,6 +262,7 @@ namespace Priority_Queue
         /// If queue is empty, result is undefined
         /// O(log n)
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T Dequeue()
         {
             #if DEBUG
@@ -251,7 +279,23 @@ namespace Priority_Queue
             #endif
 
             T returnMe = _nodes[1];
-            Remove(returnMe);
+            //If the node is already the last node, we can remove it immediately
+            if (1 == _numNodes)
+            {
+                _nodes[_numNodes] = null;
+                _numNodes--;
+                return returnMe;
+            }
+
+            //Swap the node with the last node
+            T formerLastNode = _nodes[_numNodes];
+            _nodes[1] = formerLastNode;
+            formerLastNode.QueueIndex = 1;
+            _nodes[_numNodes] = null;
+            _numNodes--;
+
+            //Now bubble formerLastNode (which is no longer the last node) down
+            CascadeDown(formerLastNode);
             return returnMe;
         }
 
@@ -276,10 +320,7 @@ namespace Priority_Queue
 
             T[] newArray = new T[maxNodes + 1];
             int highestIndexToCopy = Math.Min(maxNodes, _numNodes);
-            for (int i = 1; i <= highestIndexToCopy; i++)
-            {
-                newArray[i] = _nodes[i];
-            }
+            Array.Copy(_nodes, newArray, highestIndexToCopy + 1);
             _nodes = newArray;
         }
 
@@ -332,10 +373,9 @@ namespace Priority_Queue
         private void OnNodeUpdated(T node)
         {
             //Bubble the updated node up or down as appropriate
-            int parentIndex = node.QueueIndex / 2;
-            T parentNode = _nodes[parentIndex];
+            int parentIndex = node.QueueIndex >> 1;
 
-            if(parentIndex > 0 && HasHigherPriority(node, parentNode))
+            if(parentIndex > 0 && HasHigherPriority(node, _nodes[parentIndex]))
             {
                 CascadeUp(node);
             }
@@ -365,7 +405,8 @@ namespace Priority_Queue
             #endif
 
             //If the node is already the last node, we can remove it immediately
-            if(node.QueueIndex == _numNodes)
+            int index = node.QueueIndex;
+            if(index == _numNodes)
             {
                 _nodes[_numNodes] = null;
                 _numNodes--;
@@ -374,7 +415,8 @@ namespace Priority_Queue
 
             //Swap the node with the last node
             T formerLastNode = _nodes[_numNodes];
-            Swap(node, formerLastNode);
+            _nodes[index] = formerLastNode;
+            formerLastNode.QueueIndex = index;
             _nodes[_numNodes] = null;
             _numNodes--;
 

--- a/Priority Queue/FastPriorityQueue.cs
+++ b/Priority Queue/FastPriorityQueue.cs
@@ -22,12 +22,12 @@ namespace Priority_Queue
         /// <param name="maxNodes">The max nodes ever allowed to be enqueued (going over this will cause undefined behavior)</param>
         public FastPriorityQueue(int maxNodes)
         {
-            #if DEBUG
+#if DEBUG
             if (maxNodes <= 0)
             {
                 throw new InvalidOperationException("New queue size cannot be smaller than 1");
             }
-            #endif
+#endif
 
             _numNodes = 0;
             _nodes = new T[maxNodes + 1];
@@ -61,9 +61,9 @@ namespace Priority_Queue
         /// Removes every node from the queue.
         /// O(n) (So, don't do this often!)
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         public void Clear()
         {
             Array.Clear(_nodes, 1, _numNodes);
@@ -73,12 +73,12 @@ namespace Priority_Queue
         /// <summary>
         /// Returns (in O(1)!) whether the given node is in the queue.  O(1)
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         public bool Contains(T node)
         {
-            #if DEBUG
+#if DEBUG
             if(node == null)
             {
                 throw new ArgumentNullException("node");
@@ -87,7 +87,7 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("node.QueueIndex has been corrupted. Did you change it manually? Or add this node to another queue?");
             }
-            #endif
+#endif
 
             return (_nodes[node.QueueIndex] == node);
         }
@@ -98,12 +98,12 @@ namespace Priority_Queue
         /// If the node is already enqueued, the result is undefined.
         /// O(log n)
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         public void Enqueue(T node, float priority)
         {
-            #if DEBUG
+#if DEBUG
             if(node == null)
             {
                 throw new ArgumentNullException("node");
@@ -116,7 +116,7 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("Node is already enqueued: " + node);
             }
-            #endif
+#endif
 
             node.Priority = priority;
             _numNodes++;
@@ -125,58 +125,117 @@ namespace Priority_Queue
             CascadeUp(node);
         }
 
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
-        private void Swap(T node1, T node2)
-        {
-            // Cache to local for faster repeated access
-            int index1 = node1.QueueIndex;
-            int index2 = node2.QueueIndex;
-
-            //Swap the nodes
-            _nodes[index1] = node2;
-            _nodes[index2] = node1;
-
-            //Swap their indicies
-            node1.QueueIndex = index2;
-            node2.QueueIndex = index1;
-        }
-
-        //Performance appears to be slightly better when this is NOT inlined o_O
+#endif
         private void CascadeUp(T node)
         {
             //aka Heapify-up
-            int nodeIndex = node.QueueIndex;
-            int parentIndex = nodeIndex >> 1;
-            float nodePriority = node.Priority;
-            while(parentIndex >= 1)
+            int parent;
+            if(node.QueueIndex > 1)
             {
-                T parent = _nodes[parentIndex];
-                if(parent.Priority < nodePriority)
+                parent = node.QueueIndex >> 1;
+                T parentNode = _nodes[parent];
+                if(HasHigherOrEqualPriority(parentNode, node))
+                    return;
+
+                //Node has lower priority value, so move parent down the heap to make room
+                _nodes[node.QueueIndex] = parentNode;
+                parentNode.QueueIndex = node.QueueIndex;
+
+                node.QueueIndex = parent;
+            }
+            else
+            {
+                return;
+            }
+            while(parent > 1)
+            {
+                parent >>= 1;
+                T parentNode = _nodes[parent];
+                if(HasHigherOrEqualPriority(parentNode, node))
                     break;
 
                 //Node has lower priority value, so move parent down the heap to make room
-                _nodes[nodeIndex] = parent;
-                parent.QueueIndex = nodeIndex;
+                _nodes[node.QueueIndex] = parentNode;
+                parentNode.QueueIndex = node.QueueIndex;
 
-                nodeIndex = parentIndex;
-                parentIndex >>= 1;
+                node.QueueIndex = parent;
             }
-            _nodes[nodeIndex] = node;
-            node.QueueIndex = nodeIndex;
+            _nodes[node.QueueIndex] = node;
         }
 
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         private void CascadeDown(T node)
         {
             //aka Heapify-down
             int finalQueueIndex = node.QueueIndex;
+            int childLeftIndex = 2 * finalQueueIndex;
+
+            // If leaf node, we're done
+            if(childLeftIndex > _numNodes)
+            {
+                return;
+            }
+
+            // Check if the left-child is higher-priority than the current node
+            int childRightIndex = childLeftIndex + 1;
+            T childLeft = _nodes[childLeftIndex];
+            if(HasHigherPriority(childLeft, node))
+            {
+                // Check if there is a right child. If not, swap and finish.
+                if(childRightIndex > _numNodes)
+                {
+                    node.QueueIndex = childLeftIndex;
+                    childLeft.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childLeft;
+                    _nodes[childLeftIndex] = node;
+                    return;
+                }
+                // Check if the left-child is higher-priority than the right-child
+                T childRight = _nodes[childRightIndex];
+                if(HasHigherPriority(childLeft, childRight))
+                {
+                    // left is highest, move it up and continue
+                    childLeft.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childLeft;
+                    finalQueueIndex = childLeftIndex;
+                }
+                else
+                {
+                    // right is even higher, move it up and continue
+                    childRight.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childRight;
+                    finalQueueIndex = childRightIndex;
+                }
+            }
+            // Not swapping with left-child, does right-child exist?
+            else if(childRightIndex > _numNodes)
+            {
+                return;
+            }
+            else
+            {
+                // Check if the right-child is higher-priority than the current node
+                T childRight = _nodes[childRightIndex];
+                if(HasHigherPriority(childRight, node))
+                {
+                    childRight.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childRight;
+                    finalQueueIndex = childRightIndex;
+                }
+                // Neither child is higher-priority than current, so finish and stop.
+                else
+                {
+                    return;
+                }
+            }
+
             while(true)
             {
-                int childLeftIndex = 2 * finalQueueIndex;
+                childLeftIndex = 2 * finalQueueIndex;
 
                 // If leaf node, we're done
                 if(childLeftIndex > _numNodes)
@@ -187,8 +246,8 @@ namespace Priority_Queue
                 }
 
                 // Check if the left-child is higher-priority than the current node
-                int childRightIndex = childLeftIndex + 1;
-                T childLeft = _nodes[childLeftIndex];
+                childRightIndex = childLeftIndex + 1;
+                childLeft = _nodes[childLeftIndex];
                 if(HasHigherPriority(childLeft, node))
                 {
                     // Check if there is a right child. If not, swap and finish.
@@ -202,7 +261,7 @@ namespace Priority_Queue
                     }
                     // Check if the left-child is higher-priority than the right-child
                     T childRight = _nodes[childRightIndex];
-                    if (HasHigherPriority(childLeft, childRight))
+                    if(HasHigherPriority(childLeft, childRight))
                     {
                         // left is highest, move it up and continue
                         childLeft.QueueIndex = finalQueueIndex;
@@ -218,7 +277,7 @@ namespace Priority_Queue
                     }
                 }
                 // Not swapping with left-child, does right-child exist?
-                else if (childRightIndex > _numNodes)
+                else if(childRightIndex > _numNodes)
                 {
                     node.QueueIndex = finalQueueIndex;
                     _nodes[finalQueueIndex] = node;
@@ -228,7 +287,7 @@ namespace Priority_Queue
                 {
                     // Check if the right-child is higher-priority than the current node
                     T childRight = _nodes[childRightIndex];
-                    if (HasHigherPriority(childRight, node))
+                    if(HasHigherPriority(childRight, node))
                     {
                         childRight.QueueIndex = finalQueueIndex;
                         _nodes[finalQueueIndex] = childRight;
@@ -249,12 +308,24 @@ namespace Priority_Queue
         /// Returns true if 'higher' has higher priority than 'lower', false otherwise.
         /// Note that calling HasHigherPriority(node, node) (ie. both arguments the same node) will return false
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         private bool HasHigherPriority(T higher, T lower)
         {
             return (higher.Priority < lower.Priority);
+        }
+
+        /// <summary>
+        /// Returns true if 'higher' has higher priority than 'lower', false otherwise.
+        /// Note that calling HasHigherOrEqualPriority(node, node) (ie. both arguments the same node) will return true
+        /// </summary>
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private bool HasHigherOrEqualPriority(T higher, T lower)
+        {
+            return (higher.Priority <= lower.Priority);
         }
 
         /// <summary>
@@ -262,12 +333,12 @@ namespace Priority_Queue
         /// If queue is empty, result is undefined
         /// O(log n)
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         public T Dequeue()
         {
-            #if DEBUG
+#if DEBUG
             if(_numNodes <= 0)
             {
                 throw new InvalidOperationException("Cannot call Dequeue() on an empty queue");
@@ -278,13 +349,13 @@ namespace Priority_Queue
                 throw new InvalidOperationException("Queue has been corrupted (Did you update a node priority manually instead of calling UpdatePriority()?" +
                                                     "Or add the same node to two different queues?)");
             }
-            #endif
+#endif
 
             T returnMe = _nodes[1];
             //If the node is already the last node, we can remove it immediately
-            if (1 == _numNodes)
+            if(_numNodes == 1)
             {
-                _nodes[_numNodes] = null;
+                _nodes[1] = null;
                 _numNodes = 0;
                 return returnMe;
             }
@@ -308,7 +379,7 @@ namespace Priority_Queue
         /// </summary>
         public void Resize(int maxNodes)
         {
-            #if DEBUG
+#if DEBUG
             if (maxNodes <= 0)
             {
                 throw new InvalidOperationException("Queue size cannot be smaller than 1");
@@ -318,7 +389,7 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("Called Resize(" + maxNodes + "), but current queue contains " + _numNodes + " nodes");
             }
-            #endif
+#endif
 
             T[] newArray = new T[maxNodes + 1];
             int highestIndexToCopy = Math.Min(maxNodes, _numNodes);
@@ -335,12 +406,12 @@ namespace Priority_Queue
         {
             get
             {
-                #if DEBUG
+#if DEBUG
                 if(_numNodes <= 0)
                 {
                     throw new InvalidOperationException("Cannot call .First on an empty queue");
                 }
-                #endif
+#endif
 
                 return _nodes[1];
             }
@@ -352,12 +423,12 @@ namespace Priority_Queue
         /// Calling this method on a node not in the queue results in undefined behavior
         /// O(log n)
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        #endif
+#endif
         public void UpdatePriority(T node, float priority)
         {
-            #if DEBUG
+#if DEBUG
             if(node == null)
             {
                 throw new ArgumentNullException("node");
@@ -366,12 +437,15 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("Cannot call UpdatePriority() on a node which is not enqueued: " + node);
             }
-            #endif
+#endif
 
             node.Priority = priority;
             OnNodeUpdated(node);
         }
 
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private void OnNodeUpdated(T node)
         {
             //Bubble the updated node up or down as appropriate
@@ -393,9 +467,12 @@ namespace Priority_Queue
         /// If the node is not in the queue, the result is undefined.  If unsure, check Contains() first
         /// O(log n)
         /// </summary>
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public void Remove(T node)
         {
-            #if DEBUG
+#if DEBUG
             if(node == null)
             {
                 throw new ArgumentNullException("node");
@@ -404,11 +481,10 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + node);
             }
-            #endif
+#endif
 
             //If the node is already the last node, we can remove it immediately
-            int index = node.QueueIndex;
-            if(index == _numNodes)
+            if(node.QueueIndex == _numNodes)
             {
                 _nodes[_numNodes] = null;
                 _numNodes--;
@@ -417,8 +493,8 @@ namespace Priority_Queue
 
             //Swap the node with the last node
             T formerLastNode = _nodes[_numNodes];
-            _nodes[index] = formerLastNode;
-            formerLastNode.QueueIndex = index;
+            _nodes[node.QueueIndex] = formerLastNode;
+            formerLastNode.QueueIndex = node.QueueIndex;
             _nodes[_numNodes] = null;
             _numNodes--;
 
@@ -428,8 +504,13 @@ namespace Priority_Queue
 
         public IEnumerator<T> GetEnumerator()
         {
+#if NET_VERSION_4_5 // ArraySegment does not implement IEnumerable before 4.5
+            IEnumerable<T> e = new ArraySegment<T>(_nodes, 1, _numNodes);
+            return e.GetEnumerator();
+#else
             for(int i = 1; i <= _numNodes; i++)
                 yield return _nodes[i];
+#endif
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Priority Queue/GenericPriorityQueue.cs
+++ b/Priority Queue/GenericPriorityQueue.cs
@@ -148,46 +148,41 @@ namespace Priority_Queue
 #if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        private void Swap(TItem node1, TItem node2)
-        {
-            // Cache to local for faster repeated access
-            int index1 = node1.QueueIndex;
-            int index2 = node2.QueueIndex;
-
-            //Swap the nodes
-            _nodes[index1] = node2;
-            _nodes[index2] = node1;
-
-            //Swap their indicies
-            node1.QueueIndex = index2;
-            node2.QueueIndex = index1;
-        }
-
-        //Performance appears to be slightly better when this is NOT inlined o_O
         private void CascadeUp(TItem node)
         {
             //aka Heapify-up
-            int nodeIndex = node.QueueIndex;
-            int parentIndex = nodeIndex >> 1;
-            TPriority nodePriority = node.Priority;
-            long nodeInsertionIndex = node.InsertionIndex;
-            while(parentIndex >= 1)
+            int parent;
+            if (node.QueueIndex > 1)
             {
-                TItem parent = _nodes[parentIndex];
-                // Inline to replace repeated property reads with local variable reads
-                var cmp = _comparer(parent.Priority, nodePriority);
-                if (cmp < 0 || (cmp == 0 && parent.InsertionIndex < nodeInsertionIndex))
+                parent = node.QueueIndex >> 1;
+                TItem parentNode = _nodes[parent];
+                if(HasHigherPriority(parentNode, node))
+                    return;
+
+                //Node has lower priority value, so move parent down the heap to make room
+                _nodes[node.QueueIndex] = parentNode;
+                parentNode.QueueIndex = node.QueueIndex;
+
+                node.QueueIndex = parent;
+            }
+            else
+            {
+                return;
+            }
+            while(parent > 1)
+            {
+                parent >>= 1;
+                TItem parentNode = _nodes[parent];
+                if(HasHigherPriority(parentNode, node))
                     break;
 
                 //Node has lower priority value, so move parent down the heap to make room
-                _nodes[nodeIndex] = parent;
-                parent.QueueIndex = nodeIndex;
+                _nodes[node.QueueIndex] = parentNode;
+                parentNode.QueueIndex = node.QueueIndex;
 
-                nodeIndex = parentIndex;
-                parentIndex >>= 1;
+                node.QueueIndex = parent;
             }
-            _nodes[nodeIndex] = node;
-            node.QueueIndex = nodeIndex;
+            _nodes[node.QueueIndex] = node;
         }
 
 #if NET_VERSION_4_5
@@ -197,12 +192,73 @@ namespace Priority_Queue
         {
             //aka Heapify-down
             int finalQueueIndex = node.QueueIndex;
+            int childLeftIndex = 2 * finalQueueIndex;
+
+            // If leaf node, we're done
+            if(childLeftIndex > _numNodes)
+            {
+                return;
+            }
+
+            // Check if the left-child is higher-priority than the current node
+            int childRightIndex = childLeftIndex + 1;
+            TItem childLeft = _nodes[childLeftIndex];
+            if(HasHigherPriority(childLeft, node))
+            {
+                // Check if there is a right child. If not, swap and finish.
+                if(childRightIndex > _numNodes)
+                {
+                    node.QueueIndex = childLeftIndex;
+                    childLeft.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childLeft;
+                    _nodes[childLeftIndex] = node;
+                    return;
+                }
+                // Check if the left-child is higher-priority than the right-child
+                TItem childRight = _nodes[childRightIndex];
+                if(HasHigherPriority(childLeft, childRight))
+                {
+                    // left is highest, move it up and continue
+                    childLeft.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childLeft;
+                    finalQueueIndex = childLeftIndex;
+                }
+                else
+                {
+                    // right is even higher, move it up and continue
+                    childRight.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childRight;
+                    finalQueueIndex = childRightIndex;
+                }
+            }
+            // Not swapping with left-child, does right-child exist?
+            else if(childRightIndex > _numNodes)
+            {
+                return;
+            }
+            else
+            {
+                // Check if the right-child is higher-priority than the current node
+                TItem childRight = _nodes[childRightIndex];
+                if(HasHigherPriority(childRight, node))
+                {
+                    childRight.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = childRight;
+                    finalQueueIndex = childRightIndex;
+                }
+                // Neither child is higher-priority than current, so finish and stop.
+                else
+                {
+                    return;
+                }
+            }
+
             while(true)
             {
-                int childLeftIndex = 2 * finalQueueIndex;
+                childLeftIndex = 2 * finalQueueIndex;
 
                 // If leaf node, we're done
-                if (childLeftIndex > _numNodes)
+                if(childLeftIndex > _numNodes)
                 {
                     node.QueueIndex = finalQueueIndex;
                     _nodes[finalQueueIndex] = node;
@@ -210,12 +266,12 @@ namespace Priority_Queue
                 }
 
                 // Check if the left-child is higher-priority than the current node
-                int childRightIndex = childLeftIndex + 1;
-                TItem childLeft = _nodes[childLeftIndex];
-                if (HasHigherPriority(childLeft, node))
+                childRightIndex = childLeftIndex + 1;
+                childLeft = _nodes[childLeftIndex];
+                if(HasHigherPriority(childLeft, node))
                 {
                     // Check if there is a right child. If not, swap and finish.
-                    if (childRightIndex > _numNodes)
+                    if(childRightIndex > _numNodes)
                     {
                         node.QueueIndex = childLeftIndex;
                         childLeft.QueueIndex = finalQueueIndex;
@@ -225,7 +281,7 @@ namespace Priority_Queue
                     }
                     // Check if the left-child is higher-priority than the right-child
                     TItem childRight = _nodes[childRightIndex];
-                    if (HasHigherPriority(childLeft, childRight))
+                    if(HasHigherPriority(childLeft, childRight))
                     {
                         // left is highest, move it up and continue
                         childLeft.QueueIndex = finalQueueIndex;
@@ -241,7 +297,7 @@ namespace Priority_Queue
                     }
                 }
                 // Not swapping with left-child, does right-child exist?
-                else if (childRightIndex > _numNodes)
+                else if(childRightIndex > _numNodes)
                 {
                     node.QueueIndex = finalQueueIndex;
                     _nodes[finalQueueIndex] = node;
@@ -251,7 +307,7 @@ namespace Priority_Queue
                 {
                     // Check if the right-child is higher-priority than the current node
                     TItem childRight = _nodes[childRightIndex];
-                    if (HasHigherPriority(childRight, node))
+                    if(HasHigherPriority(childRight, node))
                     {
                         childRight.QueueIndex = finalQueueIndex;
                         _nodes[finalQueueIndex] = childRight;
@@ -306,9 +362,9 @@ namespace Priority_Queue
 
             TItem returnMe = _nodes[1];
             //If the node is already the last node, we can remove it immediately
-            if (1 == _numNodes)
+            if(_numNodes == 1)
             {
-                _nodes[_numNodes] = null;
+                _nodes[1] = null;
                 _numNodes = 0;
                 return returnMe;
             }
@@ -396,6 +452,9 @@ namespace Priority_Queue
             OnNodeUpdated(node);
         }
 
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private void OnNodeUpdated(TItem node)
         {
             //Bubble the updated node up or down as appropriate
@@ -417,6 +476,9 @@ namespace Priority_Queue
         /// If the node is not in the queue, the result is undefined.  If unsure, check Contains() first
         /// O(log n)
         /// </summary>
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public void Remove(TItem node)
         {
 #if DEBUG
@@ -431,8 +493,7 @@ namespace Priority_Queue
 #endif
 
             //If the node is already the last node, we can remove it immediately
-            int index = node.QueueIndex;
-            if(index == _numNodes)
+            if(node.QueueIndex == _numNodes)
             {
                 _nodes[_numNodes] = null;
                 _numNodes--;
@@ -441,8 +502,8 @@ namespace Priority_Queue
 
             //Swap the node with the last node
             TItem formerLastNode = _nodes[_numNodes];
-            _nodes[index] = formerLastNode;
-            formerLastNode.QueueIndex = index;
+            _nodes[node.QueueIndex] = formerLastNode;
+            formerLastNode.QueueIndex = node.QueueIndex;
             _nodes[_numNodes] = null;
             _numNodes--;
 
@@ -452,8 +513,13 @@ namespace Priority_Queue
 
         public IEnumerator<TItem> GetEnumerator()
         {
+#if NET_VERSION_4_5 // ArraySegment does not implement IEnumerable before 4.5
+            IEnumerable<TItem> e = new ArraySegment<TItem>(_nodes, 1, _numNodes);
+            return e.GetEnumerator();
+#else
             for(int i = 1; i <= _numNodes; i++)
                 yield return _nodes[i];
+#endif
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -240,7 +240,18 @@ namespace Priority_Queue
         {
             lock(_queue)
             {
-                EnqueueNoLock(item, priority);
+                IList<SimpleNode> nodes;
+                if (item == null)
+                {
+                    nodes = _nullNodesCache;
+                }
+                else if (!_itemToNodesCache.TryGetValue(item, out nodes))
+                {
+                    nodes = new List<SimpleNode>();
+                    _itemToNodesCache[item] = nodes;
+                }
+                SimpleNode node = EnqueueNoLockOrCache(item, priority);
+                nodes.Add(node);
             }
         }
 
@@ -301,12 +312,12 @@ namespace Priority_Queue
                 }
                 else
                 {
-                    if (!_itemToNodesCache.TryGetValue(item, out nodes) || nodes.Count == 0)
+                    if (!_itemToNodesCache.TryGetValue(item, out nodes))
                     {
                         throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + item);
                     }
                     removeMe = nodes[0];
-                    if (nodes.Count == 0)
+                    if (nodes.Count == 1)
                     {
                         _itemToNodesCache.Remove(item);
                     }

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -61,11 +61,11 @@ namespace Priority_Queue
                 return _nullNodesCache.Count > 0 ? _nullNodesCache[0] : null;
             }
 
-            if (!_itemToNodesCache.ContainsKey(item))
+            IList<SimpleNode> nodes;
+            if (!_itemToNodesCache.TryGetValue(item, out nodes))
             {
                 return null;
             }
-            IList<SimpleNode> nodes = _itemToNodesCache[item];
             return nodes.Count > 0 ? nodes[0] : null;
         }
 
@@ -80,11 +80,13 @@ namespace Priority_Queue
                 return;
             }
 
-            if (!_itemToNodesCache.ContainsKey(node.Data))
+            IList<SimpleNode> nodes;
+            if (!_itemToNodesCache.TryGetValue(node.Data, out nodes))
             {
-                _itemToNodesCache[node.Data] = new List<SimpleNode>();
+                nodes = new List<SimpleNode>();
+                _itemToNodesCache[node.Data] = nodes;
             }
-            _itemToNodesCache[node.Data].Add(node);
+            nodes.Add(node);
         }
 
         /// <summary>
@@ -98,12 +100,13 @@ namespace Priority_Queue
                 return;
             }
 
-            if (!_itemToNodesCache.ContainsKey(node.Data))
+            IList<SimpleNode> nodes;
+            if (!_itemToNodesCache.TryGetValue(node.Data, out nodes))
             {
                 return;
             }
-            _itemToNodesCache[node.Data].Remove(node);
-            if (_itemToNodesCache[node.Data].Count == 0)
+            nodes.Remove(node);
+            if (nodes.Count == 0)
             {
                 _itemToNodesCache.Remove(node.Data);
             }

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -171,7 +171,11 @@ namespace Priority_Queue
         {
             lock(_queue)
             {
-                return GetExistingNode(item) != null;
+                if (item == null)
+                {
+                    return _nullNodesCache.Count > 0;
+                }
+                return _itemToNodesCache.ContainsKey(item);
             }
         }
 

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -66,7 +66,7 @@ namespace Priority_Queue
             {
                 return null;
             }
-            return nodes.Count > 0 ? nodes[0] : null;
+            return nodes[0];
         }
 
         /// <summary>

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -288,13 +288,31 @@ namespace Priority_Queue
         {
             lock(_queue)
             {
-                SimpleNode removeMe = GetExistingNode(item);
-                if (removeMe == null)
+                SimpleNode removeMe;
+                IList<SimpleNode> nodes;
+                if (item == null)
                 {
-                    throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + item);
+                    if (_nullNodesCache.Count == 0)
+                    {
+                        throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + item);
+                    }
+                    removeMe = _nullNodesCache[0];
+                    nodes = _nullNodesCache;
+                }
+                else
+                {
+                    if (!_itemToNodesCache.TryGetValue(item, out nodes) || nodes.Count == 0)
+                    {
+                        throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + item);
+                    }
+                    removeMe = nodes[0];
+                    if (nodes.Count == 0)
+                    {
+                        _itemToNodesCache.Remove(item);
+                    }
                 }
                 _queue.Remove(removeMe);
-                RemoveFromNodeCache(removeMe);
+                nodes.Remove(removeMe);
             }
         }
 

--- a/Priority Queue/StablePriorityQueue.cs
+++ b/Priority Queue/StablePriorityQueue.cs
@@ -126,7 +126,7 @@ namespace Priority_Queue
             _nodes[_numNodes] = node;
             node.QueueIndex = _numNodes;
             node.InsertionIndex = _numNodesEverEnqueued++;
-            CascadeUp(_nodes[_numNodes]);
+            CascadeUp(node);
         }
 
         #if NET_VERSION_4_5
@@ -134,90 +134,118 @@ namespace Priority_Queue
         #endif
         private void Swap(T node1, T node2)
         {
+            // Cache to local for faster repeated access
+            int index1 = node1.QueueIndex;
+            int index2 = node2.QueueIndex;
+
             //Swap the nodes
-            _nodes[node1.QueueIndex] = node2;
-            _nodes[node2.QueueIndex] = node1;
+            _nodes[index1] = node2;
+            _nodes[index2] = node1;
 
             //Swap their indicies
-            int temp = node1.QueueIndex;
-            node1.QueueIndex = node2.QueueIndex;
-            node2.QueueIndex = temp;
+            node1.QueueIndex = index2;
+            node2.QueueIndex = index1;
         }
 
         //Performance appears to be slightly better when this is NOT inlined o_O
         private void CascadeUp(T node)
         {
             //aka Heapify-up
-            int parent = node.QueueIndex / 2;
-            while(parent >= 1)
+            int nodeIndex = node.QueueIndex;
+            int parentIndex = nodeIndex >> 1;
+            float nodePriority = node.Priority;
+            long nodeInsertionIndex = node.InsertionIndex;
+            while (parentIndex >= 1)
             {
-                T parentNode = _nodes[parent];
-                if(HasHigherPriority(parentNode, node))
+                T parent = _nodes[parentIndex];
+                if (parent.Priority < nodePriority || (parent.Priority == nodePriority && parent.InsertionIndex < nodeInsertionIndex))
                     break;
 
-                //Node has lower priority value, so move it up the heap
-                Swap(node, parentNode); //For some reason, this is faster with Swap() rather than (less..?) individual operations, like in CascadeDown()
+                //Node has lower priority value, so move parent down the heap to make room
+                _nodes[nodeIndex] = parent;
+                parent.QueueIndex = nodeIndex;
 
-                parent = node.QueueIndex / 2;
+                nodeIndex = parentIndex;
+                parentIndex >>= 1;
             }
+            _nodes[nodeIndex] = node;
+            node.QueueIndex = nodeIndex;
         }
 
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
         private void CascadeDown(T node)
         {
             //aka Heapify-down
-            T newParent;
             int finalQueueIndex = node.QueueIndex;
-            while(true)
+            while (true)
             {
-                newParent = node;
                 int childLeftIndex = 2 * finalQueueIndex;
 
-                //Check if the left-child is higher-priority than the current node
-                if(childLeftIndex > _numNodes)
+                // If leaf node, we're done
+                if (childLeftIndex > _numNodes)
                 {
-                    //This could be placed outside the loop, but then we'd have to check newParent != node twice
                     node.QueueIndex = finalQueueIndex;
                     _nodes[finalQueueIndex] = node;
                     break;
                 }
 
-                T childLeft = _nodes[childLeftIndex];
-                if(HasHigherPriority(childLeft, newParent))
-                {
-                    newParent = childLeft;
-                }
-
-                //Check if the right-child is higher-priority than either the current node or the left child
+                // Check if the left-child is higher-priority than the current node
                 int childRightIndex = childLeftIndex + 1;
-                if(childRightIndex <= _numNodes)
+                T childLeft = _nodes[childLeftIndex];
+                if (HasHigherPriority(childLeft, node))
                 {
-                    T childRight = _nodes[childRightIndex];
-                    if(HasHigherPriority(childRight, newParent))
+                    // Check if there is a right child. If not, swap and finish.
+                    if (childRightIndex > _numNodes)
                     {
-                        newParent = childRight;
+                        node.QueueIndex = childLeftIndex;
+                        childLeft.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childLeft;
+                        _nodes[childLeftIndex] = node;
+                        break;
+                    }
+                    // Check if the left-child is higher-priority than the right-child
+                    T childRight = _nodes[childRightIndex];
+                    if (HasHigherPriority(childLeft, childRight))
+                    {
+                        // left is highest, move it up and continue
+                        childLeft.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childLeft;
+                        finalQueueIndex = childLeftIndex;
+                    }
+                    else
+                    {
+                        // right is even higher, move it up and continue
+                        childRight.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childRight;
+                        finalQueueIndex = childRightIndex;
                     }
                 }
-
-                //If either of the children has higher (smaller) priority, swap and continue cascading
-                if(newParent != node)
+                // Not swapping with left-child, does right-child exist?
+                else if (childRightIndex > _numNodes)
                 {
-                    //Move new parent to its new index.  node will be moved once, at the end
-                    //Doing it this way is one less assignment operation than calling Swap()
-                    _nodes[finalQueueIndex] = newParent;
-
-                    int temp = newParent.QueueIndex;
-                    newParent.QueueIndex = finalQueueIndex;
-                    finalQueueIndex = temp;
+                    node.QueueIndex = finalQueueIndex;
+                    _nodes[finalQueueIndex] = node;
+                    break;
                 }
                 else
                 {
-                    //See note above
-                    node.QueueIndex = finalQueueIndex;
-                    _nodes[finalQueueIndex] = node;
-                    break;
+                    // Check if the right-child is higher-priority than the current node
+                    T childRight = _nodes[childRightIndex];
+                    if (HasHigherPriority(childRight, node))
+                    {
+                        childRight.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = childRight;
+                        finalQueueIndex = childRightIndex;
+                    }
+                    // Neither child is higher-priority than current, so finish and stop.
+                    else
+                    {
+                        node.QueueIndex = finalQueueIndex;
+                        _nodes[finalQueueIndex] = node;
+                        break;
+                    }
                 }
             }
         }
@@ -226,7 +254,7 @@ namespace Priority_Queue
         /// Returns true if 'higher' has higher priority than 'lower', false otherwise.
         /// Note that calling HasHigherPriority(node, node) (ie. both arguments the same node) will return false
         /// </summary>
-        #if NET_VERSION_4_5
+#if NET_VERSION_4_5
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         #endif
         private bool HasHigherPriority(T higher, T lower)
@@ -240,6 +268,9 @@ namespace Priority_Queue
         /// If queue is empty, result is undefined
         /// O(log n)
         /// </summary>
+#if NET_VERSION_4_5
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public T Dequeue()
         {
             #if DEBUG
@@ -256,7 +287,23 @@ namespace Priority_Queue
             #endif
 
             T returnMe = _nodes[1];
-            Remove(returnMe);
+            //If the node is already the last node, we can remove it immediately
+            if (1 == _numNodes)
+            {
+                _nodes[_numNodes] = null;
+                _numNodes = 0;
+                return returnMe;
+            }
+
+            //Swap the node with the last node
+            T formerLastNode = _nodes[_numNodes];
+            _nodes[1] = formerLastNode;
+            formerLastNode.QueueIndex = 1;
+            _nodes[_numNodes] = null;
+            _numNodes--;
+
+            //Now bubble formerLastNode (which is no longer the last node) down
+            CascadeDown(formerLastNode);
             return returnMe;
         }
 
@@ -281,10 +328,7 @@ namespace Priority_Queue
 
             T[] newArray = new T[maxNodes + 1];
             int highestIndexToCopy = Math.Min(maxNodes, _numNodes);
-            for (int i = 1; i <= highestIndexToCopy; i++)
-            {
-                newArray[i] = _nodes[i];
-            }
+            Array.Copy(_nodes, newArray, highestIndexToCopy + 1);
             _nodes = newArray;
         }
 
@@ -337,10 +381,9 @@ namespace Priority_Queue
         private void OnNodeUpdated(T node)
         {
             //Bubble the updated node up or down as appropriate
-            int parentIndex = node.QueueIndex / 2;
-            T parentNode = _nodes[parentIndex];
+            int parentIndex = node.QueueIndex >> 1;
 
-            if(parentIndex > 0 && HasHigherPriority(node, parentNode))
+            if (parentIndex > 0 && HasHigherPriority(node, _nodes[parentIndex]))
             {
                 CascadeUp(node);
             }
@@ -358,7 +401,7 @@ namespace Priority_Queue
         /// </summary>
         public void Remove(T node)
         {
-            #if DEBUG
+#if DEBUG
             if(node == null)
             {
                 throw new ArgumentNullException("node");
@@ -367,10 +410,11 @@ namespace Priority_Queue
             {
                 throw new InvalidOperationException("Cannot call Remove() on a node which is not enqueued: " + node);
             }
-            #endif
+#endif
 
             //If the node is already the last node, we can remove it immediately
-            if(node.QueueIndex == _numNodes)
+            int index = node.QueueIndex;
+            if (index == _numNodes)
             {
                 _nodes[_numNodes] = null;
                 _numNodes--;
@@ -379,7 +423,8 @@ namespace Priority_Queue
 
             //Swap the node with the last node
             T formerLastNode = _nodes[_numNodes];
-            Swap(node, formerLastNode);
+            _nodes[index] = formerLastNode;
+            formerLastNode.QueueIndex = index;
             _nodes[_numNodes] = null;
             _numNodes--;
 


### PR DESCRIPTION
These changes remove many repetitions of low level operations in frequently executed parts of the code, for significant performance gains. Measured performance gains include 10% update speed, 30% dequeue speed, and 28% remove speed on the fast queue, and 8.5% update speed, 25% contains speed, 9% dequeue speed, 25% remove speed, and smaller improvement in enqueue speed on the simple queue. Fast queue optimizations are also copied into the stable and generic queues for similar gains. Also, resize is nearly 4 times as fast by using a built-in array copy instead of a manual loop.

I didn't see any performance tests in the project, so I made my own for local testing as follows:
Fast queue, set size to 1000000, and create and store exactly that many basic nodes with just a string value.
- Enqueue all nodes, then clear queue, to make sure it's fully warmed up
- Enqueue all nodes with random priorities, and time it
- Update all nodes with new random priorities, and time it
- Check contains on all nodes, and time it
- Resize the queue to double, then back, 10 times each, and time it
- Dequeue until empty, and time it
- Re-enqueue all nodes, then remove all nodes, and time the remove part
- Repeat 20 times and average the times

Simple queue, create and store 1000000 `new object()` data items
- Enqueue all nodes, then clear queue, to warm up
- Enqueue all nodes with random priorities, and time it
- Update all nodes with new random priorities, and time it
- Check contains on all nodes, and time it
- Dequeue until empty, and time it
- EnqueueWithoutDuplicates all nodes, and time it
- Remove all nodes, and time it
- Repeat 20 times and average the times

I made no attempt to account for the overhead cost of the test loops and random number generation.

Result times in milliseconds:
Fast queue:

| Operation | Time Before | Time After |
| ----------- | ----- | ------- |
| Enqueue | 50 | 51 |
| Update | 96 | 87 |
| Contains | 6 | 6 |
| Resize | 409 | 106 |
| Dequeue | 992 | 762 |
| Remove | 147 | 115 |

Simple queue:

| Operation | Time Before | Time After |
| ----------- | ----- | ------- |
| Enqueue | 1080 | 1063 |
| Update | 419 | 386 |
| Contains | 216 | 172 |
| Dequeue | 1575 | 1442 |
| EnqueueWithoutDuplicates | 1143 | 1064 |
| Remove | 597 | 478 |

The decrease in fast queue enqueue speed is within random variation for the many times I ran these tests while making these changes. Fast queue contains is unaffected, all other operations are significantly faster.

By far the largest single improvement in the fast queue, besides the trivial resize change, was the rewrite of CascadeDown. Reducing the number of operations in Remove (and in the copy of it I put in Dequeue so I could remove another comparison or two) was a strong runner up, and several other changes had small but noticeable effects.

The simple queue benefited from the same changes through its wrapped GenericPriorityQueue, and also was significantly improved by various rewrites that reduce the number of times an object's hash is calculated and looked up in a dictionary, and dropping the calculation of pointless intermediate results in several places.

A further few percent improvement in most fast queue operations could be achieved by changing the priority type from `float` to `int`, or adding a copy of the fast queue with that difference - the generic queue won't do for this because the overhead of using a Comparer is too large even if the stability is removed - but I restricted myself to changes not visible to users.