### PR TITLE
Add SimplePriorityQueue.Try...() overloads that expose priority as out parameter

### DIFF
--- a/Priority Queue Tests/SimplePriorityQueueTests.cs
+++ b/Priority Queue Tests/SimplePriorityQueueTests.cs
@@ -405,6 +405,16 @@ namespace Priority_Queue_Tests
         }
 
         [Test]
+        public void TestTryFirstEmptyQueueWithPriorityOut()
+        {
+            Node first;
+            float firstPriority;
+            Assert.IsFalse(Queue.TryFirst(out first, out firstPriority));
+            Assert.IsNull(first);
+            Assert.AreEqual(0, firstPriority);
+        }
+
+        [Test]
         public void TestTryFirstWithItems()
         {
             Node node = new Node(1);
@@ -415,6 +425,21 @@ namespace Priority_Queue_Tests
             Assert.IsTrue(Queue.TryFirst(out first));
             Assert.AreEqual(node, first);
             Assert.AreEqual(1, Queue.Count);
+        }
+
+        [Test]
+        public void TestTryFirstWithItemsWithPriorityOut()
+        {
+            Node node = new Node(1);
+            Node first;
+            float firstPriority;
+
+            Enqueue(node);
+
+            Assert.IsTrue(Queue.TryFirst(out first, out firstPriority));
+            Assert.AreEqual(node, first);
+            Assert.AreEqual(1, Queue.Count);
+            Assert.AreEqual(node.Priority, firstPriority);
         }
 
         [Test]

--- a/Priority Queue Tests/SimplePriorityQueueTests.cs
+++ b/Priority Queue Tests/SimplePriorityQueueTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Priority_Queue;
@@ -426,6 +426,16 @@ namespace Priority_Queue_Tests
         }
 
         [Test]
+        public void TestTryDequeueEmptyQueueWithPriorityOut()
+        {
+            Node first;
+            float firstPriority;
+            Assert.IsFalse(Queue.TryDequeue(out first, out firstPriority));
+            Assert.IsNull(first);
+            Assert.AreEqual(0, firstPriority);
+        }
+
+        [Test]
         public void TestTryDequeueWithItems()
         {
             Node node = new Node(1);
@@ -436,6 +446,21 @@ namespace Priority_Queue_Tests
             Assert.IsTrue(Queue.TryDequeue(out first));
             Assert.AreEqual(node, first);
             Assert.AreEqual(0, Queue.Count);
+        }
+
+        [Test]
+        public void TestTryDequeueWithItemsWithPriorityOut()
+        {
+            Node node = new Node(1);
+            Node first;
+            float firstPriority;
+
+            Enqueue(node);
+
+            Assert.IsTrue(Queue.TryDequeue(out first, out firstPriority));
+            Assert.AreEqual(node, first);
+            Assert.AreEqual(0, Queue.Count);
+            Assert.AreEqual(node.Priority, firstPriority);
         }
 
         [Test]

--- a/Priority Queue Tests/SimplePriorityQueueTests.cs
+++ b/Priority Queue Tests/SimplePriorityQueueTests.cs
@@ -472,6 +472,16 @@ namespace Priority_Queue_Tests
         }
 
         [Test]
+        public void TestTryRemoveEmptyQueueWithPriorityOut()
+        {
+            Node node = new Node(1);
+            float priority;
+
+            Assert.IsFalse(Queue.TryRemove(node, out priority));
+            Assert.AreEqual(0, priority);
+        }
+
+        [Test]
         public void TestTryRemoveItemInQueue()
         {
             Node node1 = new Node(1);
@@ -499,6 +509,41 @@ namespace Priority_Queue_Tests
         }
 
         [Test]
+        public void TestTryRemoveItemInQueueWithPriorityOut()
+        {
+            Node node1 = new Node(1);
+            Node node2 = new Node(2);
+            Node node3 = new Node(3);
+
+            Enqueue(node1);
+            Enqueue(node2);
+            Enqueue(node3);
+
+            float priority;
+
+            Assert.IsTrue(Queue.Contains(node2));
+            Assert.IsTrue(Queue.TryRemove(node2, out priority));
+            Assert.AreEqual(node2.Priority, priority);
+            Assert.IsFalse(Queue.Contains(node2));
+            Assert.IsFalse(Queue.TryRemove(node2, out priority));
+            Assert.AreEqual(0, priority);
+
+            Assert.IsTrue(Queue.Contains(node3));
+            Assert.IsTrue(Queue.TryRemove(node3, out priority));
+            Assert.AreEqual(node3.Priority, priority);
+            Assert.IsFalse(Queue.Contains(node3));
+            Assert.IsFalse(Queue.TryRemove(node3, out priority));
+            Assert.AreEqual(0, priority);
+
+            Assert.IsTrue(Queue.Contains(node1));
+            Assert.IsTrue(Queue.TryRemove(node1, out priority));
+            Assert.AreEqual(node1.Priority, priority);
+            Assert.IsFalse(Queue.Contains(node1));
+            Assert.IsFalse(Queue.TryRemove(node1, out priority));
+            Assert.AreEqual(0, priority);
+        }
+
+        [Test]
         public void TestTryRemoveItemNotInQueue()
         {
             Node node1 = new Node(1);
@@ -509,6 +554,22 @@ namespace Priority_Queue_Tests
             Enqueue(node2);
 
             Assert.IsFalse(Queue.TryRemove(node3));
+        }
+
+        [Test]
+        public void TestTryRemoveItemNotInQueueWithPriorityOut()
+        {
+            Node node1 = new Node(1);
+            Node node2 = new Node(2);
+            Node node3 = new Node(3);
+
+            Enqueue(node1);
+            Enqueue(node2);
+
+            float priority;
+
+            Assert.IsFalse(Queue.TryRemove(node3, out priority));
+            Assert.AreEqual(0, priority);
         }
 
         [Test]

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -372,10 +372,12 @@ namespace Priority_Queue
         }
 
         #region Try* methods for multithreading
+        /// <summary>
         /// Get the head of the queue, without removing it (use TryDequeue() for that).
         /// Useful for multi-threading, where the queue may become empty between calls to Contains() and First
         /// Returns true if successful, false otherwise
         /// O(1)
+        /// </summary>
         public bool TryFirst(out TItem first)
         {
             if (_queue.Count > 0)

--- a/Priority Queue/SimplePriorityQueue.cs
+++ b/Priority Queue/SimplePriorityQueue.cs
@@ -397,6 +397,32 @@ namespace Priority_Queue
         }
 
         /// <summary>
+        /// Get the head of the queue, without removing it (use TryDequeue() for that) as well as its priority.
+        /// Useful for multi-threading, where the queue may become empty between calls to Contains(), First and GetPriority()
+        /// Returns true if successful, false otherwise
+        /// O(1)
+        /// </summary>
+        public bool TryFirst(out TItem first, out TPriority firstPriority)
+        {
+            if (_queue.Count > 0)
+            {
+                lock (_queue)
+                {
+                    if (_queue.Count > 0)
+                    {
+                        first = _queue.First.Data;
+                        firstPriority = _queue.First.Priority;
+                        return true;
+                    }
+                }
+            }
+
+            first = default(TItem);
+            firstPriority = default(TPriority);
+            return false;
+        }
+
+        /// <summary>
         /// Removes the head of the queue (node with minimum priority; ties are broken by order of insertion), and sets it to first.
         /// Useful for multi-threading, where the queue may become empty between calls to Contains() and Dequeue()
         /// Returns true if successful; false if queue was empty


### PR DESCRIPTION
* Add `SimplePriorityQueue.TryDequeue()` overload with `out TPriority` parameter and relevant unit tests
* Add `SimplePriorityQueue.TryRemove()` overload with `out TPriority` parameter and relevant unit tests
* Add `SimplePriorityQueue.TryFirst()` overload with `out TPriority` parameter and relevant unit tests

In each case if the caller wants the priority of the head/head-to-be-removed/node-to-be-removed, they can now get it without an additional `(Try)GetPriority` call, making it easier to remain thread-safe while also avoiding an extra `_itemToNodesCache` lookup.

See issue https://github.com/BlueRaja/High-Speed-Priority-Queue-for-C-Sharp/issues/54